### PR TITLE
Fix strings being converted to lowercase

### DIFF
--- a/src/Yaml/Parser/Ast.elm
+++ b/src/Yaml/Parser/Ast.elm
@@ -37,7 +37,7 @@ fromString string =
         Nothing ->
           case String.toFloat other of
             Just float -> Float_ float
-            Nothing -> String_ other
+            Nothing -> String_ string
 
 
 


### PR DESCRIPTION
When testing different possible value types, the final `String_` case branch didn't use the original string that was passed in. So instead, it was passing along a lowercase version!

This pull request closes issue #1.